### PR TITLE
Update og tags for beacon.gnosischain.com

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,19 +8,19 @@
         <meta name="description" content={{.Meta.Description}}>
         <meta property="og:title" content="{{.Meta.Title}}"/>
         <meta property="og:type" content="website"/>
-        <meta property="og:image" content="https://beaconcha.in/img/logo.png"/>
+        <meta property="og:image" content="https://beacon.gnosischain.com/img/logo.png"/>
         <meta property="og:image:alt" content="The beaconcha.in logo is a satelite dish expanding its signal."/>
         <meta property="og:description" content="{{.Meta.Description}}"/>
-        <meta property="og:url" content="https://beaconcha.in{{.Meta.Path}}"/>
-        <meta property="og:site_name" content="beaconcha.in"/>
+        <meta property="og:url" content="https://beacon.gnosischain.com{{.Meta.Path}}"/>
+        <meta property="og:site_name" content="beacon.gnosischain.com"/>
         <meta name="twitter:card" content="summary"/>
         <meta name="twitter:site" content="@etherchain_org"/>
         <meta name="twitter:title" content="{{.Meta.Title}}"/>
         <meta property="twitter:description" content="{{.Meta.Description}}"/>
-        <meta property="twitter:image" content="https://beaconcha.in/img/logo.png"/>
+        <meta property="twitter:image" content="https://beacon.gnosischain.com/img/logo.png"/>
         <meta property="twitter:image:alt" content="The beaconcha.in logo is a satelite dish expanding its signal."/>
 
-        <link rel="canonical" href="https://beaconcha.in{{.Meta.Path}}"/>
+        <link rel="canonical" href="https://beacon.gnosischain.com{{.Meta.Path}}"/>
         <title>{{.Meta.Title}}</title>
         <link rel="shortcut icon" type="image/png" href="/favicon.ico"/>
         <link rel="stylesheet" href="/css/fontawesome.min.css">


### PR DESCRIPTION
When sharing a link of GBC Explorer in some devices it resolves to beaconcha.in instead of gbc version. Updating og tags in main template will solve this issue